### PR TITLE
GraalVM 21.3.0 (OpenJDK 17)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM debian:buster-slim
 MAINTAINER Jason Hambly www.linkedin.com/in/jason-hambly
 
 # External package versions
-ENV GRAALVM_VERSION=21.1.0
-ENV OPENJDK_VERSION=16
+ENV GRAALVM_VERSION=21.3.0
+ENV OPENJDK_VERSION=17
 ENV MAVEN_VERSION=3.8.1
 
 # Environment variables

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Dockerfile for building a GraalVM and Maven image
 
 Binary Versions:
 
-GraalVM CE: 21.1.0-java16 <br/>
-OpenJDK: Java16 <br/>
+GraalVM CE: 21.1.0-java17 <br/>
+OpenJDK: Java17 <br/>
 Maven: 3.8.1
 
 ## Running


### PR DESCRIPTION
Updated GraalVM to version 21.3.0